### PR TITLE
Fix waitForPendingSubTests

### DIFF
--- a/test/lab/tap.js
+++ b/test/lab/tap.js
@@ -22,7 +22,8 @@ exports.runUsing = function() {
 
 exports.waitForPendingSubTests = function() {
   return new Promise(function(resolve, reject) {
-    tap.current().test(function() {
+    tap.current().test(function(tt) {
+      tt.end();
       resolve();
     });
   });


### PR DESCRIPTION
Fix waitForPendingSubTests() to correctly signal the end of the stub test case
created.

The problem was discovered by CI build on Windows Node v0.10, this commit
should make the build green again.
