### PR TITLE
Drop Worker::UnhandledError

### DIFF
--- a/src/worker.h
+++ b/src/worker.h
@@ -67,7 +67,6 @@ class Worker {
 
     UvError AsyncInit(AsyncWrap<Worker>* handle,
                       AsyncWrap<Worker>::Callback callback);
-    void UnhandledError(const char* msg);
 
     inline UvError UvResult(int res) const {
       return UvLastError(res, event_loop_);


### PR DESCRIPTION
Add a new method "PrintError", rework all places that were previously calling UnhandledError to print the error and gracefuly recover instead.

Close strongloop-internal/scrum-loopback#264

/to @bnoordhuis please review
