### PR TITLE
Fix expected function descriptions on Node v4

### DIFF
--- a/test/debugger-setVariableValue.test.js
+++ b/test/debugger-setVariableValue.test.js
@@ -50,6 +50,13 @@ l.runUsing(l.debugScript(SCRIPT_UNDER_TEST), function(client) {
       }
     );
 
+    // 'function () { [native code] }'
+    var logDescription = String(console.log);
+    // Workaround for a bug in V8 4.5
+    // toString result: "function bound bound ASSERT() { [native code] }"
+    // debugger result: "function bound () { [native code] }"
+    logDescription = logDescription.replace('bound bound ASSERT', 'bound ');
+
     testRefSetter(
       'console.log', // a function
       function(valueId) {
@@ -57,7 +64,7 @@ l.runUsing(l.debugScript(SCRIPT_UNDER_TEST), function(client) {
           type: 'function',
           objectId: valueId,
           className: 'Function',
-          description: String(console.log) // 'function () { [native code] }'
+          description: logDescription,
         };
       }
     );

--- a/test/runtime-callFunctionOn-setProperty.test.js
+++ b/test/runtime-callFunctionOn-setProperty.test.js
@@ -53,11 +53,18 @@ l.runUsing(l.debugScript(SCRIPT_UNDER_TEST), function(client) {
       description: 'InspectedClass'
     });
 
+    // 'function () { [native code] }'
+    var logDescription = String(console.log);
+    // Workaround for a bug in V8 4.5
+    // toString result: "function bound bound ASSERT() { [native code] }"
+    // debugger result: "function bound () { [native code] }"
+    logDescription = logDescription.replace('bound bound ASSERT', 'bound ');
+
     testSetter({
       type: 'function',
       objectId: s.ref('aFunctionId'),
       className: 'Function',
-      description: String(console.log) // 'function () { [native code] }'
+      description: logDescription,
     });
 
     // helpers (implementation details) below this line


### PR DESCRIPTION
The v8 shipped in Node v4 produces a different description of a function when called via `fn.toString` or via debugger API.

This patch adds string mangling to ensure we end up with the same description in the tests.

/to @bnoordhuis please review
