### PR TITLE
Compute code-coverage of backend files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,5 @@ checkstyle.xml
 *.tgz
 test/fixtures/generated-*.js
 backend.cov
+coverage/
+.nyc_output/

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ node_modules
 checkstyle.xml
 *.tgz
 test/fixtures/generated-*.js
+backend.cov

--- a/.jscsrc
+++ b/.jscsrc
@@ -18,6 +18,7 @@
   "excludeFiles": [
     "node_modules/**",
     "coverage/**",
+    "backend.cov/**",
     "test/fixtures/generated-*.js"
   ]
 }

--- a/.jshintignore
+++ b/.jshintignore
@@ -2,3 +2,4 @@ app.js
 node_modules/
 coverage/
 test/fixtures/
+backend.cov/

--- a/index.js
+++ b/index.js
@@ -4,8 +4,16 @@ var bindings = require('bindings');
 var dbg = bindings('debugger');
 var debuglogEnabled = require('debug')('strong-debugger').enabled;
 
-var workerPath = require.resolve('./backend/context.js');
-var scriptRoot = path.dirname(workerPath) + path.sep;
+var GATHER_CODE_COVERAGE = process.env.NYC_CWD; // jscs:disable
+var COVERAGE_REPORT_INDEX = 0;
+var COVERAGE_REPORT_BASE = path.join(__dirname, '.nyc_output',
+                                     process.pid + '-backend-');
+
+var SCRIPT_ROOT = [
+  path.dirname(require.resolve('./backend/context.js')),
+  GATHER_CODE_COVERAGE ? '.cov' : '',
+  path.sep
+].join('');
 
 var startCallbacks = [];
 var stopCallbacks = [];
@@ -34,8 +42,10 @@ exports.start = function(port, cb) {
   try {
     dbg.start({
       port: port,
-      scriptRoot: scriptRoot,
-      debuglogEnabled: debuglogEnabled
+      scriptRoot: SCRIPT_ROOT,
+      debuglogEnabled: debuglogEnabled,
+      codeCoverageReport: GATHER_CODE_COVERAGE ?
+        COVERAGE_REPORT_BASE + COVERAGE_REPORT_INDEX++ + '.json' : undefined
     }, onStarted);
   } catch (err) {
     startCallbacks = [];

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
   "gypfile": true,
   "scripts": {
     "install": "node-gyp rebuild",
-    "pretest": "jscs . && jshint .",
+    "instrument": "istanbul instrument --output backend.cov --no-compact --preserve-comments backend",
+    "pretest": "jscs . && jshint . && npm run instrument",
     "test": "tap test/lab/*.test.js test/*.test.js"
   },
   "license": "SEE LICENSE IN LICENSE",
@@ -29,6 +30,7 @@
     "chai": "^2.3.0",
     "debug": "^2.2.0",
     "dirty-chai": "^1.2.1",
+    "istanbul": "~0.3.20",
     "jscs": "^2.1.1",
     "jshint": "^2.6.0",
     "newline-json": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "install": "node-gyp rebuild",
     "instrument": "istanbul instrument --output backend.cov --no-compact --preserve-comments backend",
     "pretest": "jscs . && jshint . && npm run instrument",
-    "test": "tap test/lab/*.test.js test/*.test.js"
+    "test": "tap test/lab/*.test.js test/*.test.js",
+    "coverage": "nyc tap test/lab/*.test.js test/*.test.js"
   },
   "license": "SEE LICENSE IN LICENSE",
   "dependencies": {
@@ -34,6 +35,7 @@
     "jscs": "^2.1.1",
     "jshint": "^2.6.0",
     "newline-json": "^0.1.1",
+    "nyc": "^3.2.2",
     "split": "^1.0.0",
     "tap": "^1.2.0",
     "ws": "^0.8.0"

--- a/src/controller.cc
+++ b/src/controller.cc
@@ -18,9 +18,11 @@ static Controller * singleton = NULL;
 Controller::Controller(Isolate* main_isolate,
                        uv_loop_t* main_loop,
                        const char* script_root,
+                       const char* code_coverage_report,
                        bool debuglog_enabled)
   : isolate_(main_isolate), event_loop_(main_loop),
-    worker_(this, script_root, debuglog_enabled), start_cb_(NULL) {
+    worker_(this, script_root, code_coverage_report, debuglog_enabled),
+    start_cb_(NULL) {
 }
 
 Controller::~Controller() {

--- a/src/controller.h
+++ b/src/controller.h
@@ -27,6 +27,7 @@ class Controller {
     Controller(Isolate* main_isolate,
                uv_loop_t* main_loop,
                const char* script_root,
+               const char* code_coverage_report,
                bool debuglog_enabled);
 
     static Controller* GetInstance(Isolate* isolate);

--- a/src/debugger.cc
+++ b/src/debugger.cc
@@ -71,6 +71,10 @@ NAN_METHOD(Start) {
   }
   Nan::Utf8String script_root(val);
 
+  key = Nan::New("codeCoverageReport").ToLocalChecked();
+  val = Nan::Get(options, key).ToLocalChecked();
+  Nan::Utf8String code_coverage_report(val);
+
   key = Nan::New("debuglogEnabled").ToLocalChecked();
   val = Nan::Get(options, key).ToLocalChecked();
   if (!val->IsBoolean()) {
@@ -88,6 +92,7 @@ NAN_METHOD(Start) {
     controller = new Controller(info.GetIsolate(),
                                 uv_default_loop(),
                                 *script_root,
+                                *code_coverage_report,
                                 debuglog_enabled);
   }
 

--- a/src/worker.cc
+++ b/src/worker.cc
@@ -19,10 +19,12 @@ static void PrintError(const char* error, UvError cause = UvOk) {
 
 Worker::Worker(Controller* controller,
                const char* script_root,
+               const char* code_coverage_report,
                bool debuglog_enabled)
   : controller_(controller), start_result_(NULL), server_port_(-1),
     running_(false),
     isolate_(NULL), event_loop_(NULL),
+    code_coverage_report_(code_coverage_report),
     debuglog_enabled_(debuglog_enabled) {
   CHECK(!!controller_);
 
@@ -123,6 +125,9 @@ void Worker::Cleanup() {
   stop_signal_.CloseIfInitialized();
   debugger_messages_.CloseIfInitialized();
   server_.CloseIfInitialized(NULL);
+
+  if (!code_coverage_report_.empty())
+    WriteCodeCoverageReport();
 
   if (isolate_) {
     isolate_->Dispose();

--- a/src/worker.h
+++ b/src/worker.h
@@ -37,7 +37,8 @@ class Controller;
 class Worker {
   public:
     Worker(Controller* controller,
-           const char* worker_script,
+           const char* script_root,
+           const char* code_coverage_report,
            bool debuglog_enabled);
 
     // API for Controller, may be called from another thread
@@ -125,6 +126,7 @@ class Worker {
     std::vector<ScriptDefinition> scripts_;
     void LoadScriptFile(const char* script_root, const char* filepath);
 
+    std::string code_coverage_report_;
     bool debuglog_enabled_;
 
     // V8 bindings
@@ -135,6 +137,8 @@ class Worker {
     static JS_METHOD(DisableDebugger);
     static JS_METHOD(SendDebuggerCommand);
     static JS_METHOD(Log);
+
+    void WriteCodeCoverageReport();
 };
 
 } // namespace debugger

--- a/test/debugger-pause.test.js
+++ b/test/debugger-pause.test.js
@@ -6,9 +6,17 @@ var SCRIPT_UNDER_TEST = l.fixture(function infiniteCounter() {
   /*jshint -W087 */
   console.log('press ENTER to start...');
   process.stdin.once('data', function() {
+    // This is tricky. We need a code that spends most of the time in JS land
+    // so that Debugger.pause stops in a JS frame, but at the same time
+    // we need to allow Node runtime to process messages from the test
+    // (e.g. to stop the process and dump code coverage data)
     var counter = 0;
-    while (true)
-      counter++;
+    runForSomeTime();
+    function runForSomeTime() {
+      do { counter++; } while (counter % 1000000);
+      // Take a break, let Node runtime to process other async events
+      setImmediate(runForSomeTime);
+    }
   });
 });
 


### PR DESCRIPTION
When the module is running under a code-coverage tool nyc (tap --cov), then load instrumented backend files from "backend.cov" and write code coverage data to a file whenever the debugger backend is stopped.

Connect to strongloop-internal/scrum-loopback#469

/to @rmg @bnoordhuis please review

I am not entirely happy that we will be shipping code-coverage related hacks to npmjs, but then I don't know any better way how to compute code coverage of backend files running in a custom non-Node isolate. Do you?

Current code coverage report:

```
-------------------------------------------|----------|----------|----------|----------|----------------|
File                                       |  % Stmts | % Branch |  % Funcs |  % Lines |Uncovered Lines |
-------------------------------------------|----------|----------|----------|----------|----------------|
 Users/bajtos/src/strong/debugger/backend/ |    79.37 |    64.01 |    91.87 |    83.03 |                |
  context.js                               |    78.42 |    62.82 |    95.45 |    79.39 |... 311,312,332 |
  convert.js                               |    76.92 |    64.29 |    95.83 |    78.07 |... 280,281,283 |
  debugger-agent.js                        |    79.84 |     58.9 |    91.67 |     88.6 |... 300,301,302 |
  page-agent.js                            |    69.23 |       60 |    63.64 |       75 |... 62,84,88,92 |
  runtime-agent.js                         |    89.06 |       80 |      100 |    93.22 | 58,122,178,185 |
 __root__/                                 |       88 |       70 |     87.5 |     91.3 |                |
  ./index.js                               |       88 |       70 |     87.5 |     91.3 |    34,35,82,83 |
-------------------------------------------|----------|----------|----------|----------|----------------|
All files                                  |    80.19 |     64.4 |     91.6 |    83.81 |                |
-------------------------------------------|----------|----------|----------|----------|----------------|
```
